### PR TITLE
use pip to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6-dev"  # 3.6 development branch
 # command to install dependencies
 install:
-  - python setup.py install
+  - pip install .
 # command to run tests
 script:
   - cd tests && cd auto_test && python -m unittest && cd ../data &&  python -m unittest && cd ../generator && python -m unittest && cd ../..


### PR DESCRIPTION
Maybe pip has a different strategy from easy_install to handle dependence.